### PR TITLE
Change Log Category is not Defined as Log Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This logger is made by a developer for the developers to make their logging expe
 ### Steps to use
 #### Step-1 : Initialize a class object
 ````
-import {APDevLogger, trace, logCategory, logTypes} from "apdev-logger";;
+import {APDevLogger, trace, logLevel, logTypes} from "apdev-logger";;
 const  apLogger  =  new  APDevLogger({type:  logTypes.TEXT,  colorized:true,  switch:  'on'});
 ````
 **type:** logTypes.JSON | logTypes.TEXT ( default: TEXT ) - ~~*optional*~~ <br />
@@ -18,13 +18,13 @@ const  apLogger  =  new  APDevLogger({type:  logTypes.TEXT,  colorized:true,  sw
 
 #### Step-2 : Use the instance
 ````
-apLogger.log(logCategory.DEBUG,'Reaching this checkpoint...',trace());
-apLogger.log(logCategory.INFO,'User is active now!');
-apLogger.log(logCategory.SUCCESS,'Successfully stored Data');
-apLogger.log(logCategory.WARNING,'Database connection is down!',trace());
-apLogger.log(logCategory.ERROR,'Failed to save User data',trace());
+apLogger.log(logLevel.DEBUG,'Reaching this checkpoint...',trace());
+apLogger.log(logLevel.INFO,'User is active now!');
+apLogger.log(logLevel.SUCCESS,'Successfully stored Data');
+apLogger.log(logLevel.WARNING,'Database connection is down!',trace());
+apLogger.log(logLevel.ERROR,'Failed to save User data',trace());
 ````
-Param-1: Category of logs <br />
+Param-1: Level of logs <br />
 Param-2: Message string / stringify json <br />
 Param-3: If want to add line tracing to logs - ~~*optional*~~ <br />
 

--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,7 @@ interface configs {
     colorized?: boolean,
 }
 
-export enum logCategory {
+export enum logLevel {
     DEBUG = 'DEBUG',
     INFO = 'INFO',
     SUCCESS = 'SUCCESS',
@@ -43,7 +43,7 @@ export enum logCategory {
 }
 
 interface logInterface {
-    category: logCategory,
+    level: logLevel,
     message: string,
     trace?: string,
 }
@@ -79,13 +79,13 @@ export class APDevLogger {
             return logString;
         }
         else {
-            let logCategory = log.category.slice();
+            let logLevel = log.level.slice();
             for (let i=0; i<8; i++) {
-                if (!logCategory[i]) {
-                    logCategory = logCategory + ' ';
+                if (!logLevel[i]) {
+                    logLevel = logLevel + ' ';
                 }
             }
-            logString = logCategory + ' |-| ' + log.message;
+            logString = logLevel + ' |-| ' + log.message;
             if (this.isLineTrace) {
                 logString = logString + ' ' + log.trace;
             }
@@ -93,7 +93,7 @@ export class APDevLogger {
         }
     }
 
-    log (category: logCategory, message: string, trace?: string) {
+    log (level: logLevel, message: string, trace?: string) {
         let logColor;
         if (trace) {
             this.isLineTrace = true;
@@ -102,24 +102,24 @@ export class APDevLogger {
             this.isLineTrace = false;
         }
         const log: logInterface = {
-            category,
+            level,
             message,
             trace,
         }
-        switch (category) {
-            case logCategory.DEBUG:
+        switch (level) {
+            case logLevel.DEBUG:
                 logColor = '\x1b[35m';
                 break;
-            case logCategory.INFO:
+            case logLevel.INFO:
                 logColor = '\x1b[34m';
                 break;
-            case logCategory.SUCCESS:
+            case logLevel.SUCCESS:
                 logColor = '\x1b[32m';
                 break;
-            case logCategory.WARNING:
+            case logLevel.WARNING:
                 logColor = '\x1b[33m';
                 break;
-            case logCategory.ERROR:
+            case logLevel.ERROR:
                 logColor = '\x1b[31m';
                 break;
             default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apdev-logger",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Logger made for beutifying logging exeperience for developers",
   "main": "build/index.js",
   "repository": {
@@ -18,7 +18,10 @@
     "custom",
     "developer",
     "logging",
-    "logs"
+    "logs",
+    "typescript",
+    "javascript",
+    "node"
   ],
   "dependencies": {
     "typescript": "^5.1.6"


### PR DESCRIPTION
As most of the cloud platform directly detect level key as logging parameters, I adjusted category to be called level as per logging standards. Functionality will be the same just category key in JSON logs will be replaced by level.